### PR TITLE
fix: home and blogposts pages responsiveness

### DIFF
--- a/css/blogposts/mobile.css
+++ b/css/blogposts/mobile.css
@@ -26,31 +26,32 @@
   }
 
   .postbox {
-    display: grid;
-    grid-template-areas:
-      "img"
-      "text";
-    height: 500px;
-    width: 80%; /* Full width for smaller screens */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: auto;
+    width: 80%;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     border-radius: 8px;
     overflow: hidden;
+    margin-bottom: 10px;
+    margin-top: 10px;
   }
+
   .postbox-image,
   .postbox-image-img {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-items: center;
-    width: 250px;
-    height: 250px;
-    grid-area: img;
+    justify-content: center;
+    width: 180px;
+    height: 180px;
+    border-radius: 8px;
   }
 
   .postbox-image-caption {
-    margin-top: 20px;
     text-align: center;
-    grid-area: img;
+    margin-top: 20px;
   }
 
   .postbox-content {
@@ -59,30 +60,35 @@
     align-items: center;
     text-align: center;
     color: beige;
-    grid-area: text;
+    padding: 20px;
   }
 
   .postbox-content h3 {
     margin: 10px 0;
-    grid-area: text;
   }
 
   .postbox-content p {
     margin: 5px 0;
     color: beige;
-    grid-area: text;
+  }
+
+  .read-more-btn-wrapper {
+    display: flex;
+    justify-content: center;
+    width: 100%;
   }
 
   .read-more-btn {
     padding: 10px 20px;
     margin-top: 10px;
-    cursor: pointer;
-    grid-area: text;
     background-color: #007bff;
+    color: white;
+    border-radius: 5px;
+    cursor: pointer;
     border: 2px solid #007bff;
   }
 
   .read-more-btn:hover {
-    grid-area: text;
+    background-color: #0056b3;
   }
 }

--- a/css/blogposts/tablet.css
+++ b/css/blogposts/tablet.css
@@ -1,20 +1,21 @@
 @media (max-width: 1200px) and (min-width: 600px) {
   .container {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: auto;
     grid-template-areas:
-      "hd"
-      "postbox";
+      "hd hd hd "
+      "postbox postbox postbox ";
   }
 
   .header {
-    flex-direction: column;
+    /* flex-direction: column; */
+    grid-area: hd;
   }
 
   .hd {
     margin: 20px;
     padding: 10px;
-    font-size: 25px;
+    font-size: 30px;
   }
 
   .blogposts {

--- a/css/core/postbox.css
+++ b/css/core/postbox.css
@@ -16,6 +16,7 @@
   width: 180px;
   height: 180px;
   object-fit: cover;
+  border-radius: 8px;
 }
 
 .postbox-image-caption {

--- a/css/home/main.css
+++ b/css/home/main.css
@@ -1,4 +1,6 @@
 @import url("../core/main.css");
 @import url("./default.css");
-@import url("./tablet.css");
-@import url("./mobile.css");
+/* improve this later on */
+/* @import url("./tablet.css"); */
+/* @import url("./mobile.css"); */
+@import url("./tablet_and_mobile.css");

--- a/css/home/tablet.css
+++ b/css/home/tablet.css
@@ -1,12 +1,11 @@
 @media (max-width: 900px) and (min-width: 600px) {
   .container {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto;
-    grid-template-areas:
-      "hd"
-      "intro"
-      "bp"
-      "ft";
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    padding: 10px;
+    box-sizing: border-box;
   }
 
   .header {

--- a/css/home/tablet_and_mobile.css
+++ b/css/home/tablet_and_mobile.css
@@ -1,4 +1,4 @@
-@media (max-width: 600px) {
+@media (max-width: 750px) {
   .container {
     display: flex;
     flex-direction: column;
@@ -88,16 +88,16 @@
   }
 
   .postbox {
-    display: grid;
-    grid-template-areas:
-      "img"
-      "text";
-    height: 500px;
-    width: 80%; /* Full width for smaller screens */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: auto;
+    width: 80%;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     border-radius: 8px;
     overflow: hidden;
-    grid-area: img;
+    margin-bottom: 10px;
+    margin-top: 10px;
   }
 
   .postbox-image,
@@ -105,16 +105,15 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-items: center;
-    width: 250px;
-    height: 250px;
-    grid-area: img;
+    justify-content: center;
+    width: 180px;
+    height: 180px;
+    border-radius: 8px;
   }
 
   .postbox-image-caption {
-    margin-top: 20px;
     text-align: center;
-    grid-area: img;
+    margin-top: 20px;
   }
 
   .postbox-content {
@@ -123,18 +122,22 @@
     align-items: center;
     text-align: center;
     color: beige;
-    grid-area: text;
+    padding: 20px;
   }
 
   .postbox-content h3 {
     margin: 10px 0;
-    grid-area: text;
   }
 
   .postbox-content p {
     margin: 5px 0;
     color: beige;
-    grid-area: text;
+  }
+
+  .read-more-btn-wrapper {
+    display: flex;
+    justify-content: center;
+    width: 100%;
   }
 
   .read-more-btn {
@@ -144,13 +147,11 @@
     color: white;
     border-radius: 5px;
     cursor: pointer;
-    grid-area: text;
     border: 2px solid #007bff;
   }
 
   .read-more-btn:hover {
     background-color: #0056b3;
-    grid-area: text;
   }
 
   .footer {


### PR DESCRIPTION
Home and blogposts pages tablet-size header was aligned vertical, instead of horizontal (as they are in normal screen sizes and mobile). This commit makes the tablet-size header aligned with other.

Also the blogpost images were not aligned with caption in tablet and mobile sizes. This commit aligns them all.

closes #4 